### PR TITLE
feat: Add 'Run on Start' option

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -15,8 +15,8 @@ jobs:
     name: Build binary
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION

This commit introduces an option to make the application run on Windows startup.

The changes include:
- Added a 'ToggleRunOnStart' event.
- Added a checkable "Run on Start" item to the tray icon menu.
- Implemented `is_run_on_start_enabled()` to check the registry for the autostart setting (HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run - "RustCat").
- Implemented `set_run_on_start(enable: bool)` to add or remove the "RustCat" value from the startup registry key. This function also retrieves the current executable path.
- The event loop now handles `ToggleRunOnStart` to call `set_run_on_start` and updates the menu item's check state.
- The initial state of the "Run on Start" menu item is set correctly when the application starts and when the menu is rebuilt (e.g., after theme/icon changes).