### PR TITLE
Use mainline trayicon crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-trayicon = { git = "https://github.com/bearice/trayicon-rs.git" }
+trayicon = "0.3.0"
 flate2 = "1.0"
 
 


### PR DESCRIPTION
Since my [PR](https://github.com/Ciantic/trayicon-rs/pull/11) was merged, we can switch it back.