### PR TITLE
🧪 [testing improvement] Add unit test for IconManager::supports_themes with empty manager

### DIFF
--- a/src/icon_manager.rs
+++ b/src/icon_manager.rs
@@ -251,3 +251,16 @@ impl Default for IconManager {
         Self::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_supports_themes_empty_manager() {
+        let manager = IconManager::new();
+        assert!(!manager.supports_themes("cat"));
+        assert!(!manager.supports_themes("parrot"));
+        assert!(!manager.supports_themes(""));
+    }
+}


### PR DESCRIPTION
### 🎯 What: The testing gap addressed
Added a unit test for `IconManager::supports_themes` when using an empty `IconManager`.

### 📊 Coverage: What scenarios are now tested
- Verifies that `supports_themes` returns `false` for any icon name when the manager is newly initialized.
- Covers scenarios with valid icon names ("cat", "parrot") and an empty string.

### ✨ Result: The improvement in test coverage
Introduced the first automated unit test to the project, establishing a pattern for testing `IconManager` functionality without external dependencies.

---
*PR created automatically by Jules for task [432283218453623839](https://jules.google.com/task/432283218453623839) started by @bearice*