### PR TITLE
🔒 Fix Improper Output Neutralization in AppleScript

### DIFF
--- a/src/platform/macos/system_integration.rs
+++ b/src/platform/macos/system_integration.rs
@@ -9,8 +9,8 @@ impl SystemIntegration for MacosSystemIntegration {
             .arg("-e")
             .arg(&format!(
                 r#"display dialog "{}" with title "{}" buttons {{"OK"}} default button "OK""#,
-                message.replace("\"", "\\\""),
-                title.replace("\"", "\\\"")
+                message.replace("\\", "\\\\").replace("\"", "\\\""),
+                title.replace("\\", "\\\\").replace("\"", "\\\"")
             ))
             .spawn()?;
         Ok(())


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is Improper Output Neutralization in AppleScript strings within the `show_dialog` function.
⚠️ **Risk:** An attacker could provide a specially crafted message or title containing backslashes to escape the intended string context and execute arbitrary AppleScript commands.
🛡️ **Solution:** The fix adds `.replace("\\", "\\\\")` before `.replace("\"", "\\\"")` for both message and title, ensuring that backslashes themselves are properly escaped and cannot interfere with the string delimiters.

---
*PR created automatically by Jules for task [11615348745991779792](https://jules.google.com/task/11615348745991779792) started by @bearice*