### PR TITLE
fix(ci): force-reinstall packaging tools when cache is warm

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -150,9 +150,9 @@ jobs:
       - name: Install packaging tools
         run: |
           # cargo-deb builds .deb packages
-          cargo install --locked cargo-deb
+          cargo install --locked --force cargo-deb
           # cargo-generate-rpm builds .rpm packages
-          cargo install --locked cargo-generate-rpm
+          cargo install --locked --force cargo-generate-rpm
 
       - name: Build .deb
         run: cargo deb --no-strip --output RustCat-linux-x86_64.deb


### PR DESCRIPTION
The cargo bin dir is cached across runs. Once cargo-deb / cargo-generate-rpm are installed, a later `cargo install --locked cargo-deb` fails with `binary already exists in destination` (exit 101), breaking every subsequent Linux job — including the v2.4.0 release run. Add `--force` so the installs are idempotent whether or not the cache is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)